### PR TITLE
Fix site owner comparisons for turn switching

### DIFF
--- a/game.py
+++ b/game.py
@@ -185,7 +185,9 @@ class Game:
         # auto-select a site owned by next player
         for p in self.planets:
             for s in p.sites:
-                if s.owner == self.current_player():
+                # s.owner is stored as a string ("Blue"/"Red"),
+                # so compare against the current player's name
+                if s.owner == self.current_player().name:
                     self.selected_site = s
                     self.update_preview()
                     return
@@ -522,7 +524,8 @@ class Game:
         if not self.selected_site:
             for p in self.planets:
                 for s in p.sites:
-                    if s.owner == self.current_player():
+                    # s.owner is a string identifier; match against player name
+                    if s.owner == self.current_player().name:
                         self.selected_site = s
                         self.update_preview()
                         break


### PR DESCRIPTION
## Summary
- Ensure launch sites compare stored owner strings against current player's name when cycling turns or selecting initial site

## Testing
- `python -m py_compile assets.py entities.py game.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5af81f60883258936024d86d5adb6