### PR TITLE
Lock launch angle and update controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ A starter repository for a game
 
 ## Controls
 
-Player 1: **A** angle up, **D** angle down, **S** fire  
-Player 2: **;** angle up, **'** angle down, **#** fire
+Player 1: **S** change launch site, **D** fire
+Player 2: **'** change launch site, **#** fire
+
+Rockets always fire straight up from the selected tower.
 
 Each player may fire up to 100 shots and planets require 30 hits to be destroyed.

--- a/entities.py
+++ b/entities.py
@@ -1,6 +1,6 @@
 import math, random, pygame
 import settings as cfg
-from settings import (DT, PREVIEW_DT_SCALE, G, STAR_MASS, ANGLE_LIMIT_DEG, MIN_SPEED, MAX_SPEED, YELLOW, GREEN, RED, SHOTS_PER_PLANET)
+from settings import (DT, PREVIEW_DT_SCALE, G, STAR_MASS, MIN_SPEED, MAX_SPEED, YELLOW, GREEN, RED, SHOTS_PER_PLANET)
 
 from assets import load_img
 
@@ -122,13 +122,10 @@ class LaunchSite:
             pygame.draw.circle(surf, YELLOW, (int(x), int(y)), 10, 2)
             r = 24
             base = ang - math.pi/2
-            a1 = base - math.radians(ANGLE_LIMIT_DEG) + self.planned_angle_offset
-            a2 = base + math.radians(ANGLE_LIMIT_DEG) + self.planned_angle_offset
-            for a in (a1, a2):
-                ex = x + math.cos(a) * r
-                ey = y + math.sin(a) * r
-                pygame.draw.line(surf, YELLOW, (x,y), (ex,ey), 1)
-            pygame.draw.circle(surf, (255,255,255), (int(x),int(y)), r, 1)
+            ex = x + math.cos(base) * r
+            ey = y + math.sin(base) * r
+            pygame.draw.line(surf, YELLOW, (x, y), (ex, ey), 1)
+            pygame.draw.circle(surf, (255, 255, 255), (int(x), int(y)), r, 1)
 
 class Rocket:
     def __init__(self, owner, pos, vel):


### PR DESCRIPTION
## Summary
- lock rocket launches to straight-up orientation
- add site switching and fire controls for both players
- update UI text and documentation for new controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68a5f4223bb48325b9f37a65eb8ae310