### PR TITLE
Add shooting cooldown with player-colored UI bar

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -37,3 +37,6 @@ def set_screen_metrics(w: int, h: int):
 # shots per planet (unused with player-based shots)
 SHOTS_PER_PLANET = 100
 
+# Delay required between consecutive shots (seconds)
+SHOT_COOLDOWN = 0.5
+


### PR DESCRIPTION
## Summary
- add global shot cooldown setting
- track per-player cooldowns and enforce delay between firing
- display colored cooldown progress bars above player score panels

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a60599dfec83259082ed015f96dc51